### PR TITLE
chore: update version to 5.0.6 and adjust return types in hooks

### DIFF
--- a/lib/cjs/types/hooks.types.d.ts
+++ b/lib/cjs/types/hooks.types.d.ts
@@ -24,14 +24,14 @@ export interface UseARCMethods<Model> {
     get: (args: {
         props?: ComponentProps;
         params: ComponentPropsWithRequiredModelParams;
-    }) => Promise<Response> | undefined;
+    }) => (Promise<Response> | undefined);
     /**
      * Supprime une ressource
      */
     remove: (args: {
         props?: ComponentProps;
         params: ComponentPropsWithRequiredModelParams;
-    }) => Promise<Response> | undefined;
+    }) => (Promise<Response> | undefined);
     /**
      * Crée une nouvelle ressource
      */
@@ -39,7 +39,7 @@ export interface UseARCMethods<Model> {
         props?: ComponentProps;
         params: ComponentPropsWithRequiredModelParams;
         body: any;
-    }) => Promise<Response> | undefined;
+    }) => (Promise<Response> | undefined);
     /**
      * Met à jour une ressource existante
      */
@@ -47,7 +47,7 @@ export interface UseARCMethods<Model> {
         props?: ComponentProps;
         params: ComponentPropsWithRequiredModelParams;
         body: any;
-    }) => Promise<Response> | undefined;
+    }) => (Promise<Response> | undefined);
     /**
      * Extrait les paramètres requis à partir des props
      */
@@ -59,7 +59,7 @@ export interface UseARCMethods<Model> {
     /**
      * Permet d'exécuter une requête personnalisée
      */
-    custom: (fetcher: () => Promise<Response>) => Promise<Response> | undefined;
+    custom: (fetcher: () => Promise<Response>) => (Promise<Response> | undefined);
 }
 /**
  * Type de retour complet du hook useARC

--- a/lib/esm/types/hooks.types.d.ts
+++ b/lib/esm/types/hooks.types.d.ts
@@ -24,14 +24,14 @@ export interface UseARCMethods<Model> {
     get: (args: {
         props?: ComponentProps;
         params: ComponentPropsWithRequiredModelParams;
-    }) => Promise<Response> | undefined;
+    }) => (Promise<Response> | undefined);
     /**
      * Supprime une ressource
      */
     remove: (args: {
         props?: ComponentProps;
         params: ComponentPropsWithRequiredModelParams;
-    }) => Promise<Response> | undefined;
+    }) => (Promise<Response> | undefined);
     /**
      * Crée une nouvelle ressource
      */
@@ -39,7 +39,7 @@ export interface UseARCMethods<Model> {
         props?: ComponentProps;
         params: ComponentPropsWithRequiredModelParams;
         body: any;
-    }) => Promise<Response> | undefined;
+    }) => (Promise<Response> | undefined);
     /**
      * Met à jour une ressource existante
      */
@@ -47,7 +47,7 @@ export interface UseARCMethods<Model> {
         props?: ComponentProps;
         params: ComponentPropsWithRequiredModelParams;
         body: any;
-    }) => Promise<Response> | undefined;
+    }) => (Promise<Response> | undefined);
     /**
      * Extrait les paramètres requis à partir des props
      */
@@ -59,7 +59,7 @@ export interface UseARCMethods<Model> {
     /**
      * Permet d'exécuter une requête personnalisée
      */
-    custom: (fetcher: () => Promise<Response>) => Promise<Response> | undefined;
+    custom: (fetcher: () => Promise<Response>) => (Promise<Response> | undefined);
 }
 /**
  * Type de retour complet du hook useARC

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-arc",
-  "version": "5.0.5",
+  "version": "5.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-arc",
-      "version": "5.0.5",
+      "version": "5.0.6",
       "license": "ISC",
       "dependencies": {
         "axios": "1.8.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-arc",
-  "version": "5.0.5",
+  "version": "5.0.6",
   "description": "React Abstract Redux Component",
   "_main": "lib/index.js",
   "main": "./lib/cjs/index.js",

--- a/src/types/hooks.types.ts
+++ b/src/types/hooks.types.ts
@@ -27,7 +27,7 @@ export interface UseARCMethods<Model> {
   get: (args: {
     props?: ComponentProps
     params: ComponentPropsWithRequiredModelParams
-  }) => Promise<Response> | undefined
+  }) => (Promise<Response> | undefined)
 
   /**
    * Supprime une ressource
@@ -35,7 +35,7 @@ export interface UseARCMethods<Model> {
   remove: (args: {
     props?: ComponentProps
     params: ComponentPropsWithRequiredModelParams
-  }) => Promise<Response> | undefined
+  }) => (Promise<Response> | undefined)
 
   /**
    * Crée une nouvelle ressource
@@ -44,7 +44,7 @@ export interface UseARCMethods<Model> {
     props?: ComponentProps
     params: ComponentPropsWithRequiredModelParams
     body: any
-  }) => Promise<Response> | undefined
+  }) => (Promise<Response> | undefined)
 
   /**
    * Met à jour une ressource existante
@@ -53,7 +53,7 @@ export interface UseARCMethods<Model> {
     props?: ComponentProps
     params: ComponentPropsWithRequiredModelParams
     body: any
-  }) => Promise<Response> | undefined
+  }) => (Promise<Response> | undefined)
 
   /**
    * Extrait les paramètres requis à partir des props
@@ -68,7 +68,7 @@ export interface UseARCMethods<Model> {
   /**
    * Permet d'exécuter une requête personnalisée
    */
-  custom: (fetcher: () => Promise<Response>) => Promise<Response> | undefined
+  custom: (fetcher: () => Promise<Response>) => (Promise<Response> | undefined)
 }
 
 /**


### PR DESCRIPTION
This pull request includes a version bump for the `react-arc` package and updates to the `UseARCMethods` interface in the TypeScript types to improve type clarity. The most important changes are summarized below.

### Version Update:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the package version from `5.0.5` to `5.0.6`, indicating a patch release.

### TypeScript Type Adjustments:
* [`src/types/hooks.types.ts`](diffhunk://#diff-92e517291c8c6023cdf0d1031a3193af77de95c23786d8f972132f0da5459699L30-R38): Updated the return type syntax for all methods in the `UseARCMethods` interface to explicitly group `Promise<Response>` and `undefined` using parentheses for better readability and clarity. This affects the `get`, `remove`, `create`, `update`, and `custom` methods. [[1]](diffhunk://#diff-92e517291c8c6023cdf0d1031a3193af77de95c23786d8f972132f0da5459699L30-R38) [[2]](diffhunk://#diff-92e517291c8c6023cdf0d1031a3193af77de95c23786d8f972132f0da5459699L47-R47) [[3]](diffhunk://#diff-92e517291c8c6023cdf0d1031a3193af77de95c23786d8f972132f0da5459699L56-R56) [[4]](diffhunk://#diff-92e517291c8c6023cdf0d1031a3193af77de95c23786d8f972132f0da5459699L71-R71)