### PR TITLE
Release/v5 0 7

### DIFF
--- a/lib/cjs/hooks/useARC.js
+++ b/lib/cjs/hooks/useARC.js
@@ -25,20 +25,27 @@ function useARC(_a) {
         response: null,
         pending: false,
     };
+    var pendingPromise = (0, react_1.useRef)(null);
     var _b = (0, react_1.useState)(defaultState), state = _b[0], setState = _b[1];
     var handle = function (fetcher) {
-        if (state.pending)
-            return;
+        if (state.pending && pendingPromise.current) {
+            // If a request is already pending, return the existing promise
+            return pendingPromise.current;
+        }
         setState(__assign(__assign({}, state), { error: null, loading: true }));
-        return fetcher()
+        pendingPromise.current = fetcher();
+        pendingPromise.current
             .then(function (response) {
             setState(__assign(__assign({}, state), { loaded: true, error: null, loading: false, response: response }));
+            pendingPromise.current = null;
             return Promise.resolve(response);
         })
             .catch(function (error) {
             setState(__assign(__assign({}, state), { error: error, loading: false, pending: false }));
+            pendingPromise.current = null;
             return Promise.reject(error);
         });
+        return pendingPromise.current;
     };
     var params = (0, react_1.useRef)(arc.extractParams(props));
     (0, react_1.useEffect)(function () {

--- a/lib/cjs/types/hooks.types.d.ts
+++ b/lib/cjs/types/hooks.types.d.ts
@@ -24,14 +24,14 @@ export interface UseARCMethods<Model> {
     get: (args: {
         props?: ComponentProps;
         params: ComponentPropsWithRequiredModelParams;
-    }) => (Promise<Response> | undefined);
+    }) => (Promise<Response>);
     /**
      * Supprime une ressource
      */
     remove: (args: {
         props?: ComponentProps;
         params: ComponentPropsWithRequiredModelParams;
-    }) => (Promise<Response> | undefined);
+    }) => (Promise<Response>);
     /**
      * Crée une nouvelle ressource
      */
@@ -39,7 +39,7 @@ export interface UseARCMethods<Model> {
         props?: ComponentProps;
         params: ComponentPropsWithRequiredModelParams;
         body: any;
-    }) => (Promise<Response> | undefined);
+    }) => (Promise<Response>);
     /**
      * Met à jour une ressource existante
      */
@@ -47,7 +47,7 @@ export interface UseARCMethods<Model> {
         props?: ComponentProps;
         params: ComponentPropsWithRequiredModelParams;
         body: any;
-    }) => (Promise<Response> | undefined);
+    }) => (Promise<Response>);
     /**
      * Extrait les paramètres requis à partir des props
      */
@@ -59,7 +59,7 @@ export interface UseARCMethods<Model> {
     /**
      * Permet d'exécuter une requête personnalisée
      */
-    custom: (fetcher: () => Promise<Response>) => (Promise<Response> | undefined);
+    custom: (fetcher: () => Promise<Response>) => (Promise<Response>);
 }
 /**
  * Type de retour complet du hook useARC

--- a/lib/esm/hooks/useARC.js
+++ b/lib/esm/hooks/useARC.js
@@ -22,20 +22,27 @@ export function useARC(_a) {
         response: null,
         pending: false,
     };
+    var pendingPromise = useRef(null);
     var _b = useState(defaultState), state = _b[0], setState = _b[1];
     var handle = function (fetcher) {
-        if (state.pending)
-            return;
+        if (state.pending && pendingPromise.current) {
+            // If a request is already pending, return the existing promise
+            return pendingPromise.current;
+        }
         setState(__assign(__assign({}, state), { error: null, loading: true }));
-        return fetcher()
+        pendingPromise.current = fetcher();
+        pendingPromise.current
             .then(function (response) {
             setState(__assign(__assign({}, state), { loaded: true, error: null, loading: false, response: response }));
+            pendingPromise.current = null;
             return Promise.resolve(response);
         })
             .catch(function (error) {
             setState(__assign(__assign({}, state), { error: error, loading: false, pending: false }));
+            pendingPromise.current = null;
             return Promise.reject(error);
         });
+        return pendingPromise.current;
     };
     var params = useRef(arc.extractParams(props));
     useEffect(function () {

--- a/lib/esm/types/hooks.types.d.ts
+++ b/lib/esm/types/hooks.types.d.ts
@@ -24,14 +24,14 @@ export interface UseARCMethods<Model> {
     get: (args: {
         props?: ComponentProps;
         params: ComponentPropsWithRequiredModelParams;
-    }) => (Promise<Response> | undefined);
+    }) => (Promise<Response>);
     /**
      * Supprime une ressource
      */
     remove: (args: {
         props?: ComponentProps;
         params: ComponentPropsWithRequiredModelParams;
-    }) => (Promise<Response> | undefined);
+    }) => (Promise<Response>);
     /**
      * Crée une nouvelle ressource
      */
@@ -39,7 +39,7 @@ export interface UseARCMethods<Model> {
         props?: ComponentProps;
         params: ComponentPropsWithRequiredModelParams;
         body: any;
-    }) => (Promise<Response> | undefined);
+    }) => (Promise<Response>);
     /**
      * Met à jour une ressource existante
      */
@@ -47,7 +47,7 @@ export interface UseARCMethods<Model> {
         props?: ComponentProps;
         params: ComponentPropsWithRequiredModelParams;
         body: any;
-    }) => (Promise<Response> | undefined);
+    }) => (Promise<Response>);
     /**
      * Extrait les paramètres requis à partir des props
      */
@@ -59,7 +59,7 @@ export interface UseARCMethods<Model> {
     /**
      * Permet d'exécuter une requête personnalisée
      */
-    custom: (fetcher: () => Promise<Response>) => (Promise<Response> | undefined);
+    custom: (fetcher: () => Promise<Response>) => (Promise<Response>);
 }
 /**
  * Type de retour complet du hook useARC

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-arc",
-  "version": "5.0.6",
+  "version": "5.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-arc",
-      "version": "5.0.6",
+      "version": "5.0.7",
       "license": "ISC",
       "dependencies": {
         "axios": "1.8.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-arc",
-  "version": "5.0.6",
+  "version": "5.0.7",
   "description": "React Abstract Redux Component",
   "_main": "lib/index.js",
   "main": "./lib/cjs/index.js",

--- a/src/types/hooks.types.ts
+++ b/src/types/hooks.types.ts
@@ -27,7 +27,7 @@ export interface UseARCMethods<Model> {
   get: (args: {
     props?: ComponentProps
     params: ComponentPropsWithRequiredModelParams
-  }) => (Promise<Response> | undefined)
+  }) => (Promise<Response>)
 
   /**
    * Supprime une ressource
@@ -35,7 +35,7 @@ export interface UseARCMethods<Model> {
   remove: (args: {
     props?: ComponentProps
     params: ComponentPropsWithRequiredModelParams
-  }) => (Promise<Response> | undefined)
+  }) => (Promise<Response>)
 
   /**
    * Crée une nouvelle ressource
@@ -44,7 +44,7 @@ export interface UseARCMethods<Model> {
     props?: ComponentProps
     params: ComponentPropsWithRequiredModelParams
     body: any
-  }) => (Promise<Response> | undefined)
+  }) => (Promise<Response>)
 
   /**
    * Met à jour une ressource existante
@@ -53,7 +53,7 @@ export interface UseARCMethods<Model> {
     props?: ComponentProps
     params: ComponentPropsWithRequiredModelParams
     body: any
-  }) => (Promise<Response> | undefined)
+  }) => (Promise<Response>)
 
   /**
    * Extrait les paramètres requis à partir des props
@@ -68,7 +68,7 @@ export interface UseARCMethods<Model> {
   /**
    * Permet d'exécuter une requête personnalisée
    */
-  custom: (fetcher: () => Promise<Response>) => (Promise<Response> | undefined)
+  custom: (fetcher: () => Promise<Response>) => (Promise<Response>)
 }
 
 /**


### PR DESCRIPTION
This pull request introduces enhancements to the `useARC` hook by improving handling of pending promises and updates type definitions for better consistency. It also includes a version bump in the `package.json` file. Below is a breakdown of the most important changes:

### Enhancements to `useARC` hook:

* Added a `pendingPromise` variable using `useRef` to track ongoing fetch requests. If a request is already pending, the hook now returns the existing promise instead of initiating a new one. This change ensures no duplicate requests are made while one is still in progress. (`lib/cjs/hooks/useARC.js`: [[1]](diffhunk://#diff-22fe16b044294f2d349511f570976190baf30919dda58b11962fc4356cd003c6R28-R48) `lib/esm/hooks/useARC.js`: [[2]](diffhunk://#diff-ed29b752f85c949c960bc6180c5f13a156d4e42c5718a4b97f965e3d03cc43edR25-R45) `src/hooks/useARC.ts`: [[3]](diffhunk://#diff-7193dad1cfbbcaecc0114966bb8ae68258c421af5feae5bb40c838cdd90dd068R26-R36) [[4]](diffhunk://#diff-7193dad1cfbbcaecc0114966bb8ae68258c421af5feae5bb40c838cdd90dd068R45-R55)

### Updates to type definitions:

* Modified the `UseARCMethods` interface in `src/types/hooks.types.ts` to remove `undefined` from the return types of methods like `get`, `remove`, `create`, `update`, and `custom`. These methods now consistently return a `Promise<Response>`. (`src/types/hooks.types.ts`: [[1]](diffhunk://#diff-92e517291c8c6023cdf0d1031a3193af77de95c23786d8f972132f0da5459699L30-R38) [[2]](diffhunk://#diff-92e517291c8c6023cdf0d1031a3193af77de95c23786d8f972132f0da5459699L47-R47) [[3]](diffhunk://#diff-92e517291c8c6023cdf0d1031a3193af77de95c23786d8f972132f0da5459699L56-R56) [[4]](diffhunk://#diff-92e517291c8c6023cdf0d1031a3193af77de95c23786d8f972132f0da5459699L71-R71)

### Maintenance:

* Updated the version in `package.json` from `5.0.6` to `5.0.7` to reflect the changes introduced in this pull request. (`package.json`: [package.jsonL3-R3](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3))