### PR TITLE
refactor: update useARC types to consistently return ARCResponse<Model>

### DIFF
--- a/lib/cjs/types/hooks.types.d.ts
+++ b/lib/cjs/types/hooks.types.d.ts
@@ -1,13 +1,14 @@
 import { ARC } from "../hooks/arc";
 import { ComponentProps, ComponentPropsWithRequiredModelParams } from "./components.types";
+export type ARCResponse<Model> = Model | null | undefined;
 /**
  * État interne du hook useARC
  */
-export interface UseARCState {
+export interface UseARCState<Model> {
     error: null | object;
     loading: boolean;
     loaded: boolean;
-    response: Response | null;
+    response?: ARCResponse<Model>;
     pending: boolean;
 }
 /**
@@ -24,14 +25,14 @@ export interface UseARCMethods<Model> {
     get: (args: {
         props?: ComponentProps;
         params: ComponentPropsWithRequiredModelParams;
-    }) => (Promise<Response>);
+    }) => Promise<ARCResponse<Model>>;
     /**
      * Supprime une ressource
      */
     remove: (args: {
         props?: ComponentProps;
         params: ComponentPropsWithRequiredModelParams;
-    }) => (Promise<Response>);
+    }) => Promise<ARCResponse<Model>>;
     /**
      * Crée une nouvelle ressource
      */
@@ -39,7 +40,7 @@ export interface UseARCMethods<Model> {
         props?: ComponentProps;
         params: ComponentPropsWithRequiredModelParams;
         body: any;
-    }) => (Promise<Response>);
+    }) => Promise<ARCResponse<Model>>;
     /**
      * Met à jour une ressource existante
      */
@@ -47,7 +48,7 @@ export interface UseARCMethods<Model> {
         props?: ComponentProps;
         params: ComponentPropsWithRequiredModelParams;
         body: any;
-    }) => (Promise<Response>);
+    }) => Promise<ARCResponse<Model>>;
     /**
      * Extrait les paramètres requis à partir des props
      */
@@ -59,7 +60,7 @@ export interface UseARCMethods<Model> {
     /**
      * Permet d'exécuter une requête personnalisée
      */
-    custom: (fetcher: () => Promise<Response>) => (Promise<Response>);
+    custom: (fetcher: () => Promise<ARCResponse<Model>>) => Promise<ARCResponse<Model>>;
 }
 /**
  * Type de retour complet du hook useARC
@@ -68,6 +69,6 @@ export interface UseARC<Model> {
     error: null | object;
     loading: boolean;
     loaded: boolean;
-    response: Response | null;
+    response: ARCResponse<Model>;
     arc: UseARCMethods<Model>;
 }

--- a/lib/esm/types/hooks.types.d.ts
+++ b/lib/esm/types/hooks.types.d.ts
@@ -1,13 +1,14 @@
 import { ARC } from "../hooks/arc";
 import { ComponentProps, ComponentPropsWithRequiredModelParams } from "./components.types";
+export type ARCResponse<Model> = Model | null | undefined;
 /**
  * État interne du hook useARC
  */
-export interface UseARCState {
+export interface UseARCState<Model> {
     error: null | object;
     loading: boolean;
     loaded: boolean;
-    response: Response | null;
+    response?: ARCResponse<Model>;
     pending: boolean;
 }
 /**
@@ -24,14 +25,14 @@ export interface UseARCMethods<Model> {
     get: (args: {
         props?: ComponentProps;
         params: ComponentPropsWithRequiredModelParams;
-    }) => (Promise<Response>);
+    }) => Promise<ARCResponse<Model>>;
     /**
      * Supprime une ressource
      */
     remove: (args: {
         props?: ComponentProps;
         params: ComponentPropsWithRequiredModelParams;
-    }) => (Promise<Response>);
+    }) => Promise<ARCResponse<Model>>;
     /**
      * Crée une nouvelle ressource
      */
@@ -39,7 +40,7 @@ export interface UseARCMethods<Model> {
         props?: ComponentProps;
         params: ComponentPropsWithRequiredModelParams;
         body: any;
-    }) => (Promise<Response>);
+    }) => Promise<ARCResponse<Model>>;
     /**
      * Met à jour une ressource existante
      */
@@ -47,7 +48,7 @@ export interface UseARCMethods<Model> {
         props?: ComponentProps;
         params: ComponentPropsWithRequiredModelParams;
         body: any;
-    }) => (Promise<Response>);
+    }) => Promise<ARCResponse<Model>>;
     /**
      * Extrait les paramètres requis à partir des props
      */
@@ -59,7 +60,7 @@ export interface UseARCMethods<Model> {
     /**
      * Permet d'exécuter une requête personnalisée
      */
-    custom: (fetcher: () => Promise<Response>) => (Promise<Response>);
+    custom: (fetcher: () => Promise<ARCResponse<Model>>) => Promise<ARCResponse<Model>>;
 }
 /**
  * Type de retour complet du hook useARC
@@ -68,6 +69,6 @@ export interface UseARC<Model> {
     error: null | object;
     loading: boolean;
     loaded: boolean;
-    response: Response | null;
+    response: ARCResponse<Model>;
     arc: UseARCMethods<Model>;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-arc",
-  "version": "5.0.7",
+  "version": "5.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-arc",
-      "version": "5.0.7",
+      "version": "5.0.8",
       "license": "ISC",
       "dependencies": {
         "axios": "1.8.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-arc",
-  "version": "5.0.7",
+  "version": "5.0.8",
   "description": "React Abstract Redux Component",
   "_main": "lib/index.js",
   "main": "./lib/cjs/index.js",

--- a/src/hooks/useARC.ts
+++ b/src/hooks/useARC.ts
@@ -5,7 +5,7 @@ import {
   ComponentPropsWithRequiredModelParams,
 } from "../types/components.types"
 import { ARCConfig } from "../types/config.types"
-import { UseARCMethods, UseARC, UseARCState } from "../types/hooks.types"
+import {UseARCMethods, UseARC, UseARCState, ARCResponse} from "../types/hooks.types"
 
 export function useARC<Model>({
   ARCConfig,
@@ -16,17 +16,17 @@ export function useARC<Model>({
 }): UseARC<Model> {
   const arc = new ARC({ ARCConfig })
   const defaultProps = props
-  const defaultState: UseARCState = {
+  const defaultState: UseARCState<Model> = {
     error: null,
     loading: false,
     loaded: false,
     response: null,
     pending: false,
   }
-  const pendingPromise = useRef<Promise<Response> | null>(null)
-  const [state, setState] = useState<UseARCState>(defaultState)
+  const pendingPromise = useRef<Promise< ARCResponse<Model>> | null>(null)
+  const [state, setState] = useState<UseARCState<Model>>(defaultState)
 
-  const handle = (fetcher: () => Promise<Response>) => {
+  const handle = (fetcher: () => Promise<ARCResponse<Model>>) => {
     if (state.pending && pendingPromise.current) {
       // If a request is already pending, return the existing promise
       return pendingPromise.current
@@ -105,7 +105,7 @@ export function useARC<Model>({
       arc.extractParams(props || defaultProps),
     extractParams: (props: ComponentProps) =>
       arc.extractParams(props || defaultProps),
-    custom: (fetcher: () => Promise<Response>) => {
+    custom: (fetcher: () => Promise<ARCResponse<Model>>) => {
       return handle(fetcher)
     },
   }

--- a/src/types/hooks.types.ts
+++ b/src/types/hooks.types.ts
@@ -1,14 +1,17 @@
 import { ARC } from "../hooks/arc"
 import { ComponentProps, ComponentPropsWithRequiredModelParams } from "./components.types"
 
+
+export type ARCResponse<Model> = Model | null | undefined
+
 /**
  * État interne du hook useARC
  */
-export interface UseARCState {
+export interface UseARCState<Model> {
   error: null | object
   loading: boolean
   loaded: boolean
-  response: Response | null
+  response?: ARCResponse<Model>
   pending: boolean
 }
 
@@ -27,7 +30,7 @@ export interface UseARCMethods<Model> {
   get: (args: {
     props?: ComponentProps
     params: ComponentPropsWithRequiredModelParams
-  }) => (Promise<Response>)
+  }) => Promise<ARCResponse<Model>>
 
   /**
    * Supprime une ressource
@@ -35,7 +38,7 @@ export interface UseARCMethods<Model> {
   remove: (args: {
     props?: ComponentProps
     params: ComponentPropsWithRequiredModelParams
-  }) => (Promise<Response>)
+  }) => Promise<ARCResponse<Model>>
 
   /**
    * Crée une nouvelle ressource
@@ -44,7 +47,7 @@ export interface UseARCMethods<Model> {
     props?: ComponentProps
     params: ComponentPropsWithRequiredModelParams
     body: any
-  }) => (Promise<Response>)
+  }) => Promise<ARCResponse<Model>>
 
   /**
    * Met à jour une ressource existante
@@ -53,7 +56,7 @@ export interface UseARCMethods<Model> {
     props?: ComponentProps
     params: ComponentPropsWithRequiredModelParams
     body: any
-  }) => (Promise<Response>)
+  }) => Promise<ARCResponse<Model>>
 
   /**
    * Extrait les paramètres requis à partir des props
@@ -68,7 +71,7 @@ export interface UseARCMethods<Model> {
   /**
    * Permet d'exécuter une requête personnalisée
    */
-  custom: (fetcher: () => Promise<Response>) => (Promise<Response>)
+  custom: (fetcher: () => Promise<ARCResponse<Model>>) => Promise<ARCResponse<Model>>
 }
 
 /**
@@ -78,6 +81,6 @@ export interface UseARC<Model> {
   error: null | object
   loading: boolean
   loaded: boolean
-  response: Response | null
+  response: ARCResponse<Model>
   arc: UseARCMethods<Model>
 }


### PR DESCRIPTION
This pull request introduces type safety improvements to the `useARC` hook by making it generic and ensuring that responses are strongly typed. Additionally, it updates the version of the package in `package.json`. Below is a summary of the most important changes:

### Type Safety Enhancements for `useARC` Hook
* Added a new generic type `ARCResponse<Model>` to define the structure of the response, which can be `Model | null | undefined` (`src/types/hooks.types.ts`).
* Updated the `UseARCState` interface to include the generic `Model` type and replaced `Response` with `ARCResponse<Model>` for the `response` property (`src/types/hooks.types.ts`).
* Modified the `UseARCMethods` interface to use `ARCResponse<Model>` instead of `Response` for all promise-returning methods, ensuring type safety for API responses (`src/types/hooks.types.ts`) [[1]](diffhunk://#diff-92e517291c8c6023cdf0d1031a3193af77de95c23786d8f972132f0da5459699L30-R41) [[2]](diffhunk://#diff-92e517291c8c6023cdf0d1031a3193af77de95c23786d8f972132f0da5459699L47-R50) [[3]](diffhunk://#diff-92e517291c8c6023cdf0d1031a3193af77de95c23786d8f972132f0da5459699L56-R59) [[4]](diffhunk://#diff-92e517291c8c6023cdf0d1031a3193af77de95c23786d8f972132f0da5459699L71-R74).
* Updated the `useARC` hook implementation to use the generic `Model` type, including changes to the state initialization, `useState` hook, and custom fetch handler (`src/hooks/useARC.ts`) [[1]](diffhunk://#diff-7193dad1cfbbcaecc0114966bb8ae68258c421af5feae5bb40c838cdd90dd068L19-R29) [[2]](diffhunk://#diff-7193dad1cfbbcaecc0114966bb8ae68258c421af5feae5bb40c838cdd90dd068L108-R108).

### Package Version Update
* Incremented the package version from `5.0.7` to `5.0.8` in `package.json` to reflect the changes made in this update (`package.json`).