### PR TITLE
fix: correct model push in core.js and core.ts, update version to 5.0.9

### DIFF
--- a/lib/cjs/actions/core.js
+++ b/lib/cjs/actions/core.js
@@ -204,7 +204,7 @@ function modelPicker(config, props, listOfParams) {
             temp: temp, error: error, loaded: loaded, fetching: fetching, collection: collection }, modelParams);
         var model = getModel(config, props);
         if (model) {
-            models.push();
+            models.push(model);
         }
     });
     return models;

--- a/lib/esm/actions/core.js
+++ b/lib/esm/actions/core.js
@@ -201,7 +201,7 @@ function modelPicker(config, props, listOfParams) {
             temp: temp, error: error, loaded: loaded, fetching: fetching, collection: collection }, modelParams);
         var model = getModel(config, props);
         if (model) {
-            models.push();
+            models.push(model);
         }
     });
     return models;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-arc",
-  "version": "5.0.8",
+  "version": "5.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-arc",
-      "version": "5.0.8",
+      "version": "5.0.9",
       "license": "ISC",
       "dependencies": {
         "axios": "1.8.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-arc",
-  "version": "5.0.8",
+  "version": "5.0.9",
   "description": "React Abstract Redux Component",
   "_main": "lib/index.js",
   "main": "./lib/cjs/index.js",

--- a/src/actions/core.ts
+++ b/src/actions/core.ts
@@ -243,7 +243,7 @@ function modelPicker<Model>(
     }
     const model = getModel(config, props)
     if (model) {
-      models.push()
+      models.push(model)
     }
   })
   return models


### PR DESCRIPTION
This pull request includes a bug fix for the `modelPicker` function across multiple files and a version update in the `package.json` file. The main focus is on ensuring the `modelPicker` function correctly adds models to the `models` array.

### Bug fix in `modelPicker` function:

* [`lib/cjs/actions/core.js`](diffhunk://#diff-cbb5b4534f9e0c17af627662afe0b5a93445fbc3b213d5e5170aa536b26c529bL207-R207): Fixed an issue where the `models.push()` call was incorrectly empty, ensuring the `model` is now properly added to the `models` array.
* [`lib/esm/actions/core.js`](diffhunk://#diff-93e3424778c4dabdfec0239be4dc0bec0d2739ac1d19629efa927749ad886d79L204-R204): Applied the same fix as above for the `modelPicker` function in the ESM version of the file.
* [`src/actions/core.ts`](diffhunk://#diff-c3a1e03fa1efb642473904fe05156cc9a9bb9937c3a117d922227e07506261f0L246-R246): Corrected the `models.push()` call in the TypeScript version of the `modelPicker` function to add the `model`.

### Version update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the package version from `5.0.8` to `5.0.9`, likely to reflect the bug fix.